### PR TITLE
Fix issue of having to run chef twice

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'aws_cloudwatch'
 maintainer 'Gennady Potapov'
 license 'Apache-2.0'
 description 'Provides aws_cloudwatch_agent resource'
-version '1.0.0'
+version '1.0.1'
 chef_version '>= 12.14' if respond_to?(:chef_version)
 
 supports 'ubuntu', '= 14.04'


### PR DESCRIPTION
When the cookbook is run for the first time, start the cloudwatch agent overwrites the .json configuration.
This commit allows the config-translator to run prior to starting the service for the first time.

Fixes #2 