### PR TITLE
Allow variables to be passed to amazon-cloudwatch-agent.json template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 This file is used to list changes made in each version of the aws_cloudwatch cookbook.
 
-## 1.0.2 (2019-04.07)
+## 1.0.3 (2019-10-07)
+- Allow variables to be passed to amazon-cloudwatch-agent.json template
+
+## 1.0.2 (2019-04-07)
 - Ubuntu-18.04 support
 
 ## 1.0.1 (2019-01-14)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,39 @@ Amazon CloudWatch Agent configuration file which defines which metrics/logs are 
 Place the `amazon-cloudwatch-agent.json.erb` file to `templates` directory. This is an agent configuration for metrics and logs collection.
 See AWS documentation for more information: [Manually Create or Edit the CloudWatch Agent Configuration File](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html#CloudWatch-Agent-Configuration-File-Complete-Example)
 
+### json_variables
+
+A hash of variables can be passed into the template file. This is similar to the way variables are used in the [template resource](https://docs.chef.io/resources/template/). 
+As an example, define your resource with variables:
+
+```
+aws_cloudwatch_agent 'default' do
+  action      [:install, :configure, :restart]
+  json_config 'amazon-cloudwatch-agent.json.erb'
+  json_variables  ({
+    :disks => '/'
+  })
+end
+```
+
+Then define your `amazon-cloudwatch-agent.json.erb` template:
+
+```
+{
+  "metrics": {
+    "metrics_collected": {
+      "disk": {
+        "measurement": [
+          "used_percent"
+        ],
+        "resources": [
+          <%= @disks %>
+        ]
+      }
+    }
+  }
+}
+```
 
 ### config
 
@@ -105,6 +138,7 @@ The `aws_cloudwatch_agent` resource installs AWS Cloudwatch Agent.
 * `config` - A template name for a custom `test-config.toml` file
 * `config_params` - A hash with `test-config.toml` parameters
 * `json_config` - A template name for an `amazon-cloudwatch-agent.json` file
+* `json_variables` - A hash with variables available to the `amazon-cloudwatch-agent.json` template
 
 #### Example
 
@@ -112,6 +146,9 @@ The `aws_cloudwatch_agent` resource installs AWS Cloudwatch Agent.
 aws_cloudwatch_agent 'default' do
   action          [:install, :configure, :restart]
   json_config     'amazon-cloudwatch-agent.json.erb'
+  json_variables  ({
+    :disks => '/'
+  })
   config_params   :shared_credential_profile => 'test_profile',
                   :shared_credential_file => '/etc/test_credential_file',
                   :http_proxy => 'http://192.168.0.1',

--- a/libraries/agent_installer.rb
+++ b/libraries/agent_installer.rb
@@ -7,6 +7,7 @@ module AWSCloudwatch
 
     property :config, String
     property :json_config, String
+    property :json_variables, Hash
     property :config_params, Hash, default: {'param' => 'value'}
 
     default_action :install
@@ -111,6 +112,9 @@ module AWSCloudwatch
         template json_path do
           action    :create
           source    new_resource.json_config
+          if new_resource.json_variables
+            variables new_resource.json_variables
+          end
         end
         script 'amazon-cloudwatch-agent-config-translator' do
           action :run

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'aws_cloudwatch'
 maintainer 'Gennady Potapov'
 license 'Apache-2.0'
 description 'Provides aws_cloudwatch_agent resource'
-version '1.0.2'
+version '1.0.3'
 chef_version '>= 12.14' if respond_to?(:chef_version)
 
 supports 'ubuntu', '= 14.04'


### PR DESCRIPTION
Add the ability for the config file to have dynamic content, eg. node specific values.